### PR TITLE
CIのjobsを分割して成果物を使い回すようにした

### DIFF
--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build-and-deploy:
+    # storybook.ymlにまとめたので一旦falseにする
     if: ${{ false }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -77,3 +77,43 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ vars.NETLIFY_SITE_ID }}
+
+  # ビルドされたStorybookでVRTをするジョブ
+  vrt:
+    needs: build
+    runs-on: ubuntsu-22.04
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.head_ref || github.ref_name}}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: storybook
+          path: storybook-static
+
+      - name: Run Storycap
+        run: npm run storybook-vrt:storycap
+
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS}}
+
+      - name: Set up GCP credential
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: 'trial-storybook-vrt'
+
+      - name: Run Reg-Suit
+        run: npm run storybook-vrt:reg-suit

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,22 +1,15 @@
-name: Deploy to Netlify
+# jobを分割して一つのワークフローにまとめる
+name: Storybook
 
 on:
   push:
     branches:
       - main
   pull_request:
-    branches:
-      - main
-
-permissions:
-  contents: write
-  pull-requests: write
-  statuses: write
-  deployments: write
 
 jobs:
-  build-and-deploy:
-    if: ${{ false }}
+  # Storybookをビルドするジョブ
+  build:
     runs-on: ubuntu-22.04
     timeout-minutes: 10
 
@@ -33,6 +26,34 @@ jobs:
 
       - name: Build Storybook
         run: npm run storybook:build
+
+      - name: Upload Storybook
+        uses: actions/upload-artifact@v4
+        with:
+          name: storybook
+          path: storybook-static
+          retention-days: 1
+
+  # ビルドされたStorybookをNetlifyにデプロイするジョブ
+  deploy-to-netlify:
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+      deployments: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Storybook
+        uses: actions/download-artifact@v4
+        with:
+          name: storybook
+          path: storybook-static
 
       - name: Set GitHub Deployment Environment
         id: github_deployment_environment

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref || github.ref_name}}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -81,7 +81,7 @@ jobs:
   # ビルドされたStorybookでVRTをするジョブ
   vrt:
     needs: build
-    runs-on: ubuntsu-22.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   vrt:
+    if: ${{ false }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10
 

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   vrt:
+    # storybook.ymlにまとめたので一旦falseにする
     if: ${{ false }}
     runs-on: ubuntu-22.04
     timeout-minutes: 10


### PR DESCRIPTION
StorybookをビルドしたものをデプロイとVRTで使いまわせるようにワークフローを1つにまとめて、その中でjobsで分けるように変更

## 参考

- [GitHub Actionsで実行するstorycap / reg-suit の高速化](https://tech.route06.co.jp/entry/2023/03/29/080000)
- [reg-suit と storycap で行う Visual Regression Testing の高速化](https://blog.wadackel.me/2022/vrt-performance-optimize/)